### PR TITLE
Disney+ Eyecandy

### DIFF
--- a/slyguy.disney.plus/resources/lib/plugin.py
+++ b/slyguy.disney.plus/resources/lib/plugin.py
@@ -63,22 +63,6 @@ def login(**kwargs):
     gui.refresh()
 
 @plugin.route()
-def hubs(**kwargs):
-    folder = plugin.Folder(_.HUBS)
-
-    data = api.collection_by_slug('home', 'home')
-    thumb = _image(data.get('images', []), 'thumb')
-
-    for row in data['containers']:
-        _style = row.get('style')
-        _set = row.get('set')
-        if _set and _style == 'brandSix':
-            items = _process_rows(_set.get('items', []), 'brand')
-            folder.add_items(items)
-
-    return folder
-
-@plugin.route()
 def select_profile(**kwargs):
     if userdata.get('kid_lockdown', False):
         return
@@ -161,7 +145,7 @@ def collection(slug, content_class, label=None, **kwargs):
         if not set_id:
             return None
 
-        if slug == 'home' and _style == 'brandSix':
+        if slug == 'home' and _style == 'brand':
             continue
 
         if _style in ('hero', 'WatchlistSet'):


### PR DESCRIPTION
Adds mediatype hints and updates art retrieval process to populate as many artwork types as possible, allowing the addon to work with many different view modes in Kodi, especially when using custom skins.

At first, I was afraid that doing this would slow things down, but afaict Kodi pulls the images asynchronously as needed and I haven't seen much increase in latency.

I did most of my testing with the default Estuary skin and Aeon Nox: SiLVO in Kodi 19.1. The "hubs" view is a little bit clunky in some views, because the API expects special handling of the "brand" icons, but as-is this patch does allow more options than what we had before. The "banner" image type is a bit of a stretch; most kodi skins assume banners have text, and these banners don't. But I figured it didn't hurt to grab it. If you don't prefer that part, it's easy enough to remove.

I noticed that you have pushed quite a few changes to the plugin in the last few days, so hopefully I'm not stepping on anyone's toes - let me know if you need me to change anything.