### PR TITLE
[DO NOT MERGE] Reduce Duplicate Channels

### DIFF
--- a/plugin.program.iptv.merge/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.program.iptv.merge/resources/language/resource.language.en_gb/strings.po
@@ -397,6 +397,14 @@ msgctxt "#30097"
 msgid "Hide Groups"
 msgstr ""
 
+msgctxt "#30098"
+msgid "Consolidate Duplicate Channels"
+msgstr ""
+
+msgctxt "#30099"
+msgid "Duplicate Channel Preference"
+msgstr ""
+
 ## COMMON SETTINGS ##
 
 msgctxt "#32055"

--- a/plugin.program.iptv.merge/resources/lib/merger.py
+++ b/plugin.program.iptv.merge/resources/lib/merger.py
@@ -346,8 +346,7 @@ class Merger(object):
                         channel.slug = '{}.{}'.format(slug, count)
                         count += 1
 
-                    # log.info(f'MICAHG {slug_input} => {channel.slug}')
-
+                    # TODO remove this comment
                     # MICAH slugs might get what you want. Each epg_id gets the same hash
                     # and so slugs end up looking like:
                     #
@@ -406,11 +405,9 @@ class Merger(object):
                 error = None
                 try:
                     log.debug('Processing: {}'.format(playlist.path))
-                    # log.info(f'MICAHG {playlist}')
 
                     if playlist.source_type != Playlist.TYPE_CUSTOM:
                         self._process_source(playlist, METHOD_PLAYLIST, self.tmp_file)
-                        # log.info(f'MICAHG datbase is {database}')
                         with database.db.atomic() as transaction:
                             try:
                                 added = self._process_playlist(playlist, self.tmp_file)
@@ -447,7 +444,6 @@ class Merger(object):
             starting_ch_no = settings.getInt('start_ch_no', 1)
             groups_disabled = settings.getBool('disable_groups', False)
 
-            # log.info(f'MICAHG writing to {working_path}')
             with codecs.open(working_path, 'w', encoding='utf8') as outfile:
                 outfile.write(u'#EXTM3U')
 
@@ -462,7 +458,6 @@ class Merger(object):
                     if len(channel.slug) > 8:
                         log.debug(f'Skipping duplicate channel {channel.slug}')
                         continue
-                    log.info(f'MICAHG writing {channel.slug} {channel.name}')
 
                     if channel.chno is None:
                         channel.chno = chno

--- a/plugin.program.iptv.merge/resources/lib/merger.py
+++ b/plugin.program.iptv.merge/resources/lib/merger.py
@@ -337,24 +337,13 @@ class Merger(object):
 
                     channel.groups = [x for x in channel.groups if x.strip()]
                     channel.visible = is_visible(channel)
-                    slug_input = channel.epg_id or channel.url.lower().strip()
-                    channel.slug = slug = '{}.{}'.format(playlist.id, hash_6(slug_input))
+                    channel.slug = slug = '{}.{}'.format(playlist.id, hash_6(channel.epg_id or channel.url.lower().strip()))
                     channel.order = added_count + 1
 
                     count = 1
                     while channel.slug in slugs:
                         channel.slug = '{}.{}'.format(slug, count)
                         count += 1
-
-                    # TODO remove this comment
-                    # MICAH slugs might get what you want. Each epg_id gets the same hash
-                    # and so slugs end up looking like:
-                    #
-                    # BTSPOR2 => 2.l4J1UT
-                    # BTSPOR2 => 2.l4J1UT.1
-                    # BTSPOR2 => 2.l4J1UT.2
-                    #
-                    # So they could be used to find similar channels.
 
                     slugs.add(channel.slug)
                     to_create.add(channel)
@@ -408,6 +397,7 @@ class Merger(object):
 
                     if playlist.source_type != Playlist.TYPE_CUSTOM:
                         self._process_source(playlist, METHOD_PLAYLIST, self.tmp_file)
+
                         with database.db.atomic() as transaction:
                             try:
                                 added = self._process_playlist(playlist, self.tmp_file)

--- a/plugin.program.iptv.merge/resources/lib/merger.py
+++ b/plugin.program.iptv.merge/resources/lib/merger.py
@@ -445,6 +445,7 @@ class Merger(object):
                 tv_groups = []
                 for channel in Channel.playlist_list(radio=False):
 
+                    # 8 would imply a second dot (eg: this slug indicates it is a duplicate channel by guide id)
                     if len(channel.slug) > 8:
                         log.debug(f'Skipping duplicate channel {channel.slug}')
                         continue

--- a/plugin.program.iptv.merge/resources/lib/models.py
+++ b/plugin.program.iptv.merge/resources/lib/models.py
@@ -51,7 +51,7 @@ def play_channel(slug, **kwargs):
     #     item = get_item(chan, prev_item)
     #     prev_item = item
 
-    return get_item()
+    return get_item(channels[0])
 
 def get_item(channel, play_next=None):
     # channel = Channel.get_by_id(slug)

--- a/plugin.program.iptv.merge/resources/lib/models.py
+++ b/plugin.program.iptv.merge/resources/lib/models.py
@@ -22,8 +22,12 @@ from .language import _
 
 @plugin.route()
 def play_channel(slug, **kwargs):
+    log.info('MICAHG in play_channel')
     channel = Channel.get_by_id(slug)
     split = channel.url.split('|')
+
+    log.info('MICAHG HELLO THERE')
+    log.info(f'MICAHG playing {channel}')
 
     headers = {
         'user-agent': DEFAULT_USERAGENT,

--- a/plugin.program.iptv.merge/resources/settings.xml
+++ b/plugin.program.iptv.merge/resources/settings.xml
@@ -23,7 +23,7 @@
         <setting label="30077" id="ask_to_add" type="bool" default="true"/>
         <setting label="$ADDON[script.module.slyguy 32111]" id="bookmarks" type="bool" default="false" visible="false"/>
         <setting label="30098" id="consolidate_duplicates" type="bool" default="false"/>
-        <setting label="30099" id="duplicate_prefs" type="text" default="FHD,HD,SD" subsetting="true" enable="eq(-1,true)"/>
+        <setting label="30099" id="duplicate_prefs" type="text" default="FHD,HD" subsetting="true" enable="eq(-1,true)"/>
     </category>
 
     <category label="$ADDON[script.module.slyguy 32035]">

--- a/plugin.program.iptv.merge/resources/settings.xml
+++ b/plugin.program.iptv.merge/resources/settings.xml
@@ -22,6 +22,8 @@
         <setting label="30005" id="page_size" type="number" default="200"/>
         <setting label="30077" id="ask_to_add" type="bool" default="true"/>
         <setting label="$ADDON[script.module.slyguy 32111]" id="bookmarks" type="bool" default="false" visible="false"/>
+        <setting label="30098" id="consolidate_duplicates" type="bool" default="false"/>
+        <setting label="30099" id="duplicate_prefs" type="text" default="FHD,HD,SD" subsetting="true" enable="eq(-1,true)"/>
     </category>
 
     <category label="$ADDON[script.module.slyguy 32035]">

--- a/script.module.slyguy/resources/modules/slyguy/plugin.py
+++ b/script.module.slyguy/resources/modules/slyguy/plugin.py
@@ -59,8 +59,10 @@ def route(url=None):
     def decorator(f, url):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            log.info(f'MICAHG in decorator args {args}')
+            log.info(f'MICAH kwargs {kwargs}')
             item = f(*args, **kwargs)
-
+            log.info(f'MICAH got item {item}')
             autoplay = kwargs.get(ROUTE_AUTOPLAY_TAG, None)
             autofolder = kwargs.get(ROUTE_AUTOFOLDER_TAG, None)
 
@@ -71,6 +73,7 @@ def route(url=None):
             elif isinstance(item, Folder):
                 item.display()
             elif isinstance(item, Item):
+                log.info(f'MICAH playing item')
                 item.play(**kwargs)
             elif isinstance(item, Redirect):
                 if _handle() > 0:
@@ -590,6 +593,8 @@ class Item(gui.Item):
     def play(self, **kwargs):
         self.playable = True
 
+        log.info(f'MICAHG in play kwargs {kwargs}')
+
         quality = kwargs.get(QUALITY_TAG, self.quality)
         is_live = ROUTE_LIVE_TAG in kwargs
 
@@ -621,14 +626,16 @@ class Item(gui.Item):
             if play_data['next']['next_file']:
                 play_data['next']['next_file'] = router.add_url_args(play_data['next']['next_file'], _play=1)
 
-        if self.callback:
+        if self.callback:en
             play_data['callback'].update(self.callback)
 
         set_kodi_string('_slyguy_play_data', json.dumps(play_data))
 
         if handle > 0:
+            log.info(f'MICAHG setResolvedUrl handle {handle} {li}')
             xbmcplugin.setResolvedUrl(handle, True, li)
         else:
+            log.info(f'MICAHG playing {self.path}')
             xbmc.Player().play(self.path, li)
 
 #Plugin.Folder()

--- a/script.module.slyguy/resources/modules/slyguy/plugin.py
+++ b/script.module.slyguy/resources/modules/slyguy/plugin.py
@@ -59,10 +59,7 @@ def route(url=None):
     def decorator(f, url):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            log.info(f'MICAHG in decorator args {args}')
-            log.info(f'MICAH kwargs {kwargs}')
             item = f(*args, **kwargs)
-            log.info(f'MICAH got item {item}')
             autoplay = kwargs.get(ROUTE_AUTOPLAY_TAG, None)
             autofolder = kwargs.get(ROUTE_AUTOFOLDER_TAG, None)
 
@@ -73,7 +70,6 @@ def route(url=None):
             elif isinstance(item, Folder):
                 item.display()
             elif isinstance(item, Item):
-                log.info(f'MICAH playing item')
                 item.play(**kwargs)
             elif isinstance(item, Redirect):
                 if _handle() > 0:
@@ -593,8 +589,6 @@ class Item(gui.Item):
     def play(self, **kwargs):
         self.playable = True
 
-        log.info(f'MICAHG in play kwargs {kwargs}')
-
         quality = kwargs.get(QUALITY_TAG, self.quality)
         is_live = ROUTE_LIVE_TAG in kwargs
 
@@ -626,16 +620,14 @@ class Item(gui.Item):
             if play_data['next']['next_file']:
                 play_data['next']['next_file'] = router.add_url_args(play_data['next']['next_file'], _play=1)
 
-        if self.callback:en
+        if self.callback:
             play_data['callback'].update(self.callback)
 
         set_kodi_string('_slyguy_play_data', json.dumps(play_data))
 
         if handle > 0:
-            log.info(f'MICAHG setResolvedUrl handle {handle} {li}')
             xbmcplugin.setResolvedUrl(handle, True, li)
         else:
-            log.info(f'MICAHG playing {self.path}')
             xbmc.Player().play(self.path, li)
 
 #Plugin.Folder()

--- a/script.module.slyguy/resources/modules/slyguy/router.py
+++ b/script.module.slyguy/resources/modules/slyguy/router.py
@@ -113,12 +113,9 @@ def redirect(url):
 
 # router.dispatch('?_=_settings')
 def dispatch(url):
-    log.debug(f'MICAHG dispatching "{url}"')
     with signals.throwable():
         signals.emit(signals.BEFORE_DISPATCH)
         function, params = parse_url(url)
-        log.info(f'MICAHG function is {function}')
-        log.info(f'MICAHG params are {params}')
 
         try:
             function(**params)

--- a/script.module.slyguy/resources/modules/slyguy/router.py
+++ b/script.module.slyguy/resources/modules/slyguy/router.py
@@ -113,9 +113,12 @@ def redirect(url):
 
 # router.dispatch('?_=_settings')
 def dispatch(url):
+    log.debug(f'MICAHG dispatching "{url}"')
     with signals.throwable():
         signals.emit(signals.BEFORE_DISPATCH)
         function, params = parse_url(url)
+        log.info(f'MICAHG function is {function}')
+        log.info(f'MICAHG params are {params}')
 
         try:
             function(**params)


### PR DESCRIPTION
Looking for feedback on the following changes for IPTV merge.

- Omit duplicate instances of a channel from the playlist written to pvr.iptvsimple _BUT DO_ keep it in the sqlite DB (eg: same guide ID but different URL - like if we have SD and HD of the same channel).
- On playback sort through the duplicate channels (they're pulled by slug from sqlite/peewee) and pick out the most desirable

This on its own would greatly improve my experience as a user but what I'd love to be able to do when playback fails (http 400 or something) is fallback to a lower quality stream of the same channel.

I searched around to see about callbacks on player state and there is this: https://alwinesch.github.io/group__python___player_c_b.html#ga607b028ba0625154f593aab586b7dcc0

... but I'm not sure we're making use of it...  Open to suggestions, especially considering how much lib you have built up in slyguy.  I was looking at the play_next thing but it doesn't seem to be what I'm after.