### PR TITLE
Properly set content types for directories

### DIFF
--- a/script.module.slyguy/resources/modules/slyguy/plugin.py
+++ b/script.module.slyguy/resources/modules/slyguy/plugin.py
@@ -728,12 +728,8 @@ class Folder(object):
         #     self.content = data[1]
 
         if self.content == 'AUTO':
-            if content_type == 'movies':
-                self.content = 'movies'
-            elif content_type in ('tvshows', 'seasons'):
-                self.content = 'tvshows'
-            elif content_type == 'episodes':
-                self.content = 'tvshows'
+            if content_type in ('movies', 'tvshows', 'seasons', 'episodes'):
+                self.content = content_type
             else:
                 self.content = 'videos'
 


### PR DESCRIPTION
This should make it so that viewtypes in skins can be set independently for series, seasons, and episodes.