### PR TITLE
Proxy: Retry after 5 seconds on everry Request Exception

### DIFF
--- a/script.module.slyguy/resources/lib/proxy.py
+++ b/script.module.slyguy/resources/lib/proxy.py
@@ -1241,14 +1241,16 @@ class RequestHandler(BaseHTTPRequestHandler):
         ## Fix any double // in url
         url = fix_url(url)
 
-        retries = 3
+        retries = 5
         # some reason we get connection errors every so often when using a session. something to do with the socket
         for i in range(retries):
             log.debug('REQUEST OUT: {} ({})'.format(url, method.upper()))
             try:
-                response = self._session['session'].request(method=method, url=url, headers=self._headers, data=self._post_data, allow_redirects=False, stream=True)
-            except ConnectionError as e:
-                if 'Connection aborted' not in str(e) or i == retries-1:
+                response = self._session['session'].request(
+                    method=method, url=url, headers=self._headers, timeout=5,
+                    data=self._post_data, allow_redirects=False, stream=True)
+            except RequestException as e:
+                if i == retries-1:
                     log.exception(e)
                     raise
             except Exception as e:

--- a/script.module.slyguy/resources/lib/proxy.py
+++ b/script.module.slyguy/resources/lib/proxy.py
@@ -10,7 +10,7 @@ from xml.dom.minidom import parseString
 from functools import cmp_to_key
 
 import arrow
-from requests import ConnectionError
+from requests import RequestException
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from six.moves.socketserver import ThreadingMixIn
 from six.moves.urllib.parse import urlparse, urljoin, unquote_plus, parse_qsl

--- a/script.module.slyguy/resources/lib/proxy.py
+++ b/script.module.slyguy/resources/lib/proxy.py
@@ -1241,7 +1241,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         ## Fix any double // in url
         url = fix_url(url)
 
-        retries = 5
+        retries = 3
         # some reason we get connection errors every so often when using a session. something to do with the socket
         for i in range(retries):
             log.debug('REQUEST OUT: {} ({})'.format(url, method.upper()))


### PR DESCRIPTION
I am using the Disney+ addons mainly to watch some of _The Simpsons_ episodes. 

I have been encountering playback error since some months ago. The symptom is a brutal freeze of the video playback and a loop playback of the last 50 ms of sound. The video timestamp continue to increase in the player ui. It had become almost impossible to watch an entire episode (~20 min) without encountering the error.

 I saw in the logs that this error was correlated with `requests.ReadTimeout` exceptions. So I generalized the request retry exception handling to `request.RequestException` which is a common parent type of `requests.ReadTimeout` and the previously catched `ConnectionError`. I also disabled testing the exception message. 

 This did not fix the problem at first because the default request timeout is too high (~25 seconds on my linux) and does not allow the client to get data soon enough in case of a retry. I then set the timeout to 5 seconds and the retries count to 5 (to match the total 25 seconds timeout). This allow the data to be fetched fast enough even when a retry is done.

This as fixed the bug for me, I have not anymore playback trouble. By adding log I saw that at least one retry was done during each episode, without any perceptible consequences. 

Are these settings applicable to every use cases or setups ? (I am using a quite fast fiber connection).

Thanks you very much for your work, hopping this will be useful.
