### PR TITLE
slyguy.paramount.plus: Correctly set locale

### DIFF
--- a/slyguy.paramount.plus/resources/lib/api.py
+++ b/slyguy.paramount.plus/resources/lib/api.py
@@ -252,7 +252,11 @@ class API(object):
     @mem_cache.cached(60*5)
     def show_menu(self, show_id):
         self._refresh_token()
-        return self._session.get('/v3.0/androidphone/shows/{}/menu.json'.format(show_id), params=self._params()).json()['showMenu'][0].get('links', [])
+        params = {
+            'locale': 'en-us',
+        }
+
+        return self._session.get('/v3.0/androidphone/shows/{}/menu.json'.format(show_id), params=self._params(params)).json()['showMenu'][0].get('links', [])
 
     @mem_cache.cached(60*10)
     def show(self, show_id):
@@ -266,6 +270,7 @@ class API(object):
             'platformType': 'apps',
             'rows': 1,
             'begin': 0,
+            'locale': 'en-us',
         }
         sections = self._session.get('/v2.0/androidphone/shows/{}/videos/config/{}.json'.format(show_id, config), params=self._params(params)).json()['videoSectionMetadata']
         for section in sections:

--- a/slyguy.paramount.plus/resources/lib/api.py
+++ b/slyguy.paramount.plus/resources/lib/api.py
@@ -165,7 +165,7 @@ class API(object):
         userdata.set('profile_img', profile['profilePicPath'])
 
     def _params(self, params=None):
-        _params = {'at': self._config.at_token}
+        _params = {'at': self._config.at_token, 'locale': self._config.locale}
         #_params = {'locale': 'en-us', 'at': self._at_token(secret), 'LOCATEMEIN': 'us'}
         if params:
             _params.update(params)

--- a/slyguy.paramount.plus/resources/lib/config.py
+++ b/slyguy.paramount.plus/resources/lib/config.py
@@ -81,6 +81,13 @@ class Config(object):
         return self._config['country']
 
     @property
+    def locale(self):
+        if not 'locale' in self._config:
+            self.refresh()
+
+        return self._config['locale']
+
+    @property
     def episodes_section(self):
         return CONFIG[self.region]['episodes_section']
 
@@ -146,9 +153,16 @@ class Config(object):
         if not app_version.get('availableInRegion'):
             return None
 
+        app_locale = "en-us"
+
+        for locale in data["localesSupport"]:
+            if locale["isDefaultLanguage"]:
+                app_locale = locale["lang"]
+
         config = {
             'version': ADDON_VERSION,
             'region': region,
+            'locale': app_locale,
             'country': app_version['clientRegion'],
             'mvpd': app_version['clientRegion'] in app_config.get('mvpd_enabled_countries', []),
             'live_tv': app_config.get('livetv_disabled') != 'true',


### PR DESCRIPTION
Currently most if not all of the descriptions of the Paramount+ Addon are in English, even if the account is for example German.

The supported locales are part of the client config, with one of them being marked as default. I believe this is based on geolocation, since the config is fetched before logging in. After adding it as a parameter to the URL, all texts in the addon are in the correct language.

I have not tested this extensively, and it might have some edgecases. It also doesnt allow the user to choose the locale.

This would fix #449 / #333