### PR TITLE
slyguy.paramount.plus: Implement playback sync and resume

### DIFF
--- a/slyguy.paramount.plus/resources/language/resource.language.de_de/strings.po
+++ b/slyguy.paramount.plus/resources/language/resource.language.de_de/strings.po
@@ -105,6 +105,10 @@ msgstr "Verifizierungs-Token kann nicht erneuert werden"
 "Bitte prüfen Sie, ob Ihr Abonnement noch gültig ist"
 "Versuchen Sie dann, sich abzumelden und erneut anzumelden."
 
+msgctxt "#30030"
+msgid "Sync with Paramount+"
+msgstr "Mit Paramount+ synchronisieren"
+
 ## COMMON SETTINGS ##
 
 msgctxt "#32055"

--- a/slyguy.paramount.plus/resources/language/resource.language.en_gb/strings.po
+++ b/slyguy.paramount.plus/resources/language/resource.language.en_gb/strings.po
@@ -103,6 +103,10 @@ msgid "Failed to refresh auth token\n"
 "Then try logout and login again"
 msgstr ""
 
+msgctxt "#30030"
+msgid "Sync with Paramount+"
+msgstr ""
+
 ## COMMON SETTINGS ##
 
 msgctxt "#32055"

--- a/slyguy.paramount.plus/resources/language/resource.language.nl_nl/strings.po
+++ b/slyguy.paramount.plus/resources/language/resource.language.nl_nl/strings.po
@@ -105,6 +105,10 @@ msgstr "Kan verificatietoken niet vernieuwen\n"
 "Controleer of uw abonnement nog geldig is\n"
 "Probeer vervolgens uit te loggen en opnieuw in te loggen"
 
+msgctxt "#30030"
+msgid "Sync with Paramount+"
+msgstr ""
+
 ## COMMON SETTINGS ##
 
 msgctxt "#32055"

--- a/slyguy.paramount.plus/resources/lib/api.py
+++ b/slyguy.paramount.plus/resources/lib/api.py
@@ -310,6 +310,14 @@ class API(object):
         self._refresh_token()
         return self._session.get('/v3.0/androidtv/login/status.json', params=self._params()).json()
 
+    def video(self, video_id):
+        self._refresh_token()
+
+        params = {
+            "contentId": video_id,
+        }
+        return self._session.get('/v3.0/androidphone/video/streams.json', params=self._params(params)).json()
+
     def play(self, video_id):
         self._refresh_token()
 

--- a/slyguy.paramount.plus/resources/lib/config.py
+++ b/slyguy.paramount.plus/resources/lib/config.py
@@ -89,6 +89,10 @@ class Config(object):
         return CONFIG[self.region]['episodes_section']
 
     @property
+    def base_url(self):
+        return CONFIG[self.region]['base_url']
+
+    @property
     def api_url(self):
         return CONFIG[self.region]['base_url'] + '/apps-api{}'
 

--- a/slyguy.paramount.plus/resources/lib/plugin.py
+++ b/slyguy.paramount.plus/resources/lib/plugin.py
@@ -1,5 +1,6 @@
 import time
 import codecs
+import uuid
 from xml.sax.saxutils import escape
 from xml.dom.minidom import parseString
 
@@ -681,7 +682,20 @@ def _play(video_id):
 
     item.headers['authorization'] = 'Bearer {}'.format(data['license_token'])
 
+    if settings.getBool('sync_playback', False):
+        item.callback = {
+            'type':'interval',
+            'interval': 10,
+            'callback': plugin.url_for(callback, session_id=str(uuid.uuid4()), media_id=video_id),
+        }
+
+
     return item
+
+@plugin.route()
+@plugin.no_error_gui()
+def callback(session_id, media_id, _time, **kwargs):
+    api.update_playhead(session_id, media_id, int(_time))
 
 @plugin.route()
 @plugin.login_required()

--- a/slyguy.paramount.plus/resources/settings.xml
+++ b/slyguy.paramount.plus/resources/settings.xml
@@ -17,6 +17,8 @@
         <setting label="$ADDON[script.module.slyguy 32088]" id="subs_forced" type="bool" default="true" visible="false"/>
         <setting label="$ADDON[script.module.slyguy 32089]" id="subs_non_forced" type="bool" default="true" visible="false"/>
 
+        <setting label="30030" type="bool" id="sync_playback" default="false"/>
+
         <setting label="30025" type="bool" id="ac3_enabled" default="false"/>
         <setting label="30024" type="bool" id="ec3_enabled" default="false"/>
             <setting label="30028" type="bool" id="atmos_enabled" default="false" enable="eq(-1,true)"/>


### PR DESCRIPTION
See also: https://github.com/matthuisman/slyguy.addons/issues/218#issuecomment-1678234450

This only implements syncing the current position to Paramount+ and resuming from it. The information for how to make a "Continue Watching" UI is also in the issue linked above, I will try to implement that later.

I have only tested this on the international / german Paramount+, but given how the rest of the API works, I imagine it will also work on the US version.