### PR TITLE
Update listitem.py, gui.py to support pre-formatted cast - backwards compatible.

### DIFF
--- a/script.module.slyguy/resources/modules/slyguy/gui.py
+++ b/script.module.slyguy/resources/modules/slyguy/gui.py
@@ -311,6 +311,9 @@ class Item(object):
                 if info.get('date'):
                     try: info['date'] = '{}.{}.{}'.format(info['date'][8:10], info['date'][5:7], info['date'][0:4])
                     except: pass
+                if info.get('cast'):
+                    try: info['cast'] = [(member['name'], member['role']) for member in info['cast']]
+                    except: pass
                 li.setInfo('video', info)
 
         if self.specialsort:

--- a/script.module.slyguy/resources/modules/slyguy/listitem.py
+++ b/script.module.slyguy/resources/modules/slyguy/listitem.py
@@ -156,6 +156,8 @@ class _ListItemInfoTagVideo(_ListItemInfoTag):
     def set_info_cast(self, cast: list, *args, **kwargs):
         """ Wrapper to convert cast and castandrole from ListItem.setInfo() to InfoTagVideo.setCast() """
         def _set_cast_member(x, i):
+            if isinstance(i, dict):
+                return i
             if not isinstance(i, tuple):
                 i = (i, '',)
             return {'name': f'{i[0]}', 'role': f'{i[1]}', 'order': x, 'thumbnail': ''}


### PR DESCRIPTION
Allow passing a pre-formatted cast array dict to be sent in info when adding an item to plugin.Folder.

ex:

info['cast'] = [{"name": "Albert Brooks", "role": "Marlin (voice)", "order": 0, "thumbnail": "http://image.tmdb.org/t/p/original/8iDSGu5l93N7benjf6b3AysBore.jpg"}]