### PR TITLE
Add support for UniqueIDs to gui.py for ListItems and VideoInfoTags

### DIFF
--- a/script.module.slyguy/resources/modules/slyguy/gui.py
+++ b/script.module.slyguy/resources/modules/slyguy/gui.py
@@ -330,8 +330,10 @@ class Item(object):
                     try: info['cast'] = [(member['name'], member['role']) for member in info['cast']]
                     except: pass
                 li.setInfo('video', info)
-                if isinstance(self.unique_ids,dict) and len(list(self.unique_ids.keys())):
-                    li.setUniqueIDs(self.unique_ids, self.defunique_id)
+                try:
+                    if isinstance(self.unique_ids,dict) and len(list(self.unique_ids.keys())):
+                        li.setUniqueIDs(self.unique_ids, self.defunique_id)
+                except: pass
 
         if self.specialsort:
             li.setProperty('specialsort', self.specialsort)


### PR DESCRIPTION
Adds support for setting UniqueIDs on plugin.Folder

Used in conjunction with folder.Additem

ex:

```
folder.add_item(info=info,
                        unique_ids=({'tmdb': str(603)}, 'tmdb'),
                        art=artwork,
                        path=path,
                        playable=True)
```

Accepts parameter as tuple or dict

when dict is sent the first item in the dict will be used as default:

{'tmdb': str(603)} will default to 'tmdb'

when tuple is sent the default will be added as the second item in the tuple

({'tmdb': str(603)}, 'tmdb') will be default 'tmdb' because of the added value

This behavior is as designed by the Kodi developers and outlined here https://alwinesch.github.io/group__python__xbmcgui__listitem.html#ga6cc13c6c75adf9fa922c82f783ea0f8e

But, behavior to insist on a default by selecting the first item was added because Kodi will not accept the values if there is no default sent.

Tested on

Kodi from Debian - 19.5 (19.5.0) Git:20230416-nogitfound
Self compiled Kodi - 21.0-ALPHA1 (20.90.101) Git:20230321-124023d6ff

platform Debian Bullseye for both

Reference Issue - https://github.com/matthuisman/slyguy.addons/issues/568