### PR TITLE
Add HBO headwaiter header to watch time marker update requests

### DIFF
--- a/slyguy.hbo.max/resources/lib/api.py
+++ b/slyguy.hbo.max/resources/lib/api.py
@@ -281,6 +281,10 @@ class API(object):
     def update_marker(self, url, cut_id, runtime, playback_time):
         self._refresh_token()
 
+        headers = {
+            'x-hbo-headwaiter': self._headwaiter()
+        }
+
         payload = {
             #'appSessionId': session_id,
             #'videoSessionId': video_session,
@@ -290,7 +294,7 @@ class API(object):
             'runtime': runtime,
         }
 
-        resp = self._session.post(url, json=payload)
+        resp = self._session.post(url, json=payload, headers=headers)
         if not resp.ok:
             return False
         else:


### PR DESCRIPTION
Some titles don't get their watch time synced and don't show up in "Continue Watching" without this value. It looks like it might be a feature-flagged and/or A/B-tested requirement.