### PR TITLE
[slyguy.paramount.plus] Prefer posters from `movieAssets`

### DIFF
--- a/slyguy.paramount.plus/resources/lib/plugin.py
+++ b/slyguy.paramount.plus/resources/lib/plugin.py
@@ -573,18 +573,20 @@ def _get_thumb(thumbs, _type='PosterArt', dimensions='w400'):
 def _movie_art(thumbs, assets=None):
     assets = assets or {}
 
-    art = {
-        'thumb': _get_thumb(thumbs, 'PosterArt'),
-        'fanart': _get_thumb(thumbs, 'Thumbnail', 'w1920-q80'),
+    # PosterArt 404s for some movies, so only use it as a fallback
+    if 'filepath_movie_poster' in assets:
+        thumb = config.image(assets['filepath_movie_poster'])
+    else:
+        thumb = _get_thumb(thumbs, 'PosterArt'),
+
+    fanart = _get_thumb(thumbs, 'Thumbnail', 'w1920-q80')
+    if fanart is None and 'filepath_movie_hero_sky' in assets:
+        fanart = config.image(assets['filepath_movie_hero_sky'], 'w1920-q80')
+
+    return {
+        'thumb': thumb,
+        'fanart': fanart,
     }
-
-    if not art['thumb'] and 'filepath_movie_poster' in assets:
-        art['thumb'] = config.image(assets['filepath_movie_poster'])
-
-    if not art['fanart'] and 'filepath_movie_hero_sky' in assets:
-        art['fanart'] = config.image(assets['filepath_movie_hero_sky'], 'w1920-q80')
-
-    return art
 
 @plugin.route()
 @plugin.search()


### PR DESCRIPTION
Currently, we only use the poster image in the `movieAssets` manifest object if there's no "PosterArt" entry in `thumbnailSet`. However, several movies, such as Arrival and Interstellar (see below) have "PosterArt" entries that 404, resulting in no art getting loaded. Reverse the order we try them in to fix the issue.

Example broken URLs:
 - [Arrival](https://thumbnails.cbsig.net/CBS_Production_Entertainment_VMS/ARVL_SAlone_Poster_1400x2100_NB.jpg)
 - [Interstellar](https://thumbnails.cbsig.net/CBS_Production_Entertainment_VMS/INST_SAlone_Poster_1400x2100_NB.jpg)